### PR TITLE
Pin base image for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cargo install cargo-about
 RUN cargo about generate -c .cargo-about/about.toml -o RUST_LICENSE.txt .cargo-about/about.hbs
 
 # Combine Projects
-FROM debian:bookworm-slim AS runtime
+FROM debian:12.8-slim AS runtime
 WORKDIR /app
 COPY --from=web-builder /build/crates/lib-web/dist/LICENSE.txt WEB_LICENSE.txt
 COPY --from=rust-builder /build/target/release/server server


### PR DESCRIPTION
Pin base image to Debian `12.8-slim`.