### PR TITLE
Specify exact Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ lib-api-router = { path = "crates/lib-api-router" }
 lib-web = { path = "crates/lib-web" }
 lib-web-router = { path = "crates/lib-web-router" }
 
-axum = "0.8.1"
-camino = "1.1.9"
-itertools = "0.14.0"
-phf = "0.11.2"
-tokio = { version = "1.42.0", features = ["full"] }
-phf_codegen = "0.11.2"
-glob = "0.3.2"
-mime_guess = "2.0.5"
-flate2 = "1.0.35"
+axum = "=0.8.1"
+camino = "=1.1.9"
+itertools = "=0.14.0"
+phf = "=0.11.2"
+tokio = { version = "=1.42.0", features = ["full"] }
+phf_codegen = "=0.11.2"
+glob = "=0.3.2"
+mime_guess = "=2.0.5"
+flate2 = "=1.0.35"


### PR DESCRIPTION
Add `=` to version to be exact with the version number